### PR TITLE
160439: Set Encrypted Output Props

### DIFF
--- a/src/main/zip/deploy.groovy
+++ b/src/main/zip/deploy.groovy
@@ -83,6 +83,6 @@ catch (Exception e) {
     throw e;
 }
 finally {
-    apTool.storeOutputProperties()
+    apTool.setOutputProperties(System.getenv("UCD_SECRET_VAR"))
     helper.cleanUp();
 }


### PR DESCRIPTION
Missing UCD_SECRET_KEY will cause a no-plugin-logs error state. In this scenario, the plugin step completed successfully, but it could not parse the output properties correctly. Error will look similar to below picture.
![outputprops](https://cloud.githubusercontent.com/assets/14111822/25534511/f48098e0-2c01-11e7-8c5d-6b8f97afa518.png)
