### PR TITLE
162830 Deploy and Delete Flows uses timeout

### DIFF
--- a/src/main/groovy/com/urbancode/air/plugin/wmbcmp/IIBHelper.groovy
+++ b/src/main/groovy/com/urbancode/air/plugin/wmbcmp/IIBHelper.groovy
@@ -305,8 +305,9 @@ class IIBHelper {
             throw new IllegalStateException("Execution group proxy is null! Make sure it is configured correctly!")
         }
 
-        println "${getTimestamp()} Using execution group: ${executionGroup} and waiting until a response is received..."
-        DeployResult dr = executionGroupProxy.deploy(fileName, isIncremental, AttributeConstants.DEPLOYRESULT_WAIT_INDEFINITELY)
+        println "${getTimestamp()} Using execution group: ${executionGroup} and waiting with a timeout " +
+            "of ${timeout} or until a response is received from the execution group..."
+        DeployResult dr = executionGroupProxy.deploy(fileName, isIncremental, timeout)
         CompletionCodeType completionCode = dr.getCompletionCode()
 
         checkDeployResult(dr)
@@ -465,7 +466,7 @@ class IIBHelper {
 
         if ( flowsToDelete.size() > 0) {
             println "${getTimestamp()} Deleting "+flowsToDelete.size()+" deployed objects that are orphaned"
-            println "Waiting until a response is received from the execution group..."
+            println "Waiting with a timeout of ${timeout} or until a response is received from the execution group..."
 
             // convert to DeployedObject [] to match deleteDeployedObjects method spec
             DeployedObject [] flowsToDeleteArray = new DeployedObject[flowsToDelete.size()]
@@ -476,7 +477,7 @@ class IIBHelper {
                 flowsToDeleteArray[count++] = flowsIterator.next()
             }
 
-            executionGroupProxy.deleteDeployedObjects (flowsToDeleteArray , AttributeConstants.DEPLOYRESULT_WAIT_INDEFINITELY)
+            executionGroupProxy.deleteDeployedObjects (flowsToDeleteArray, timeout)
             checkDeployResult()
         }
         else {
@@ -536,7 +537,7 @@ class IIBHelper {
 
             if (executionGroupProxy == null) {
                 throw new IllegalStateException("Execution group ${groupName} does not exist. Please make sure its " +
-			"name is spelled correctly and that it exists under the specified broker.")
+			             "name is spelled correctly and that it exists under the specified broker.")
             }
         }
         else {

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -234,11 +234,12 @@ Fixes APAR PI79634 Additional plugin decryption updates.
 Fixes APAR PI81397 Plug-in failing to import libraries.
     </release-note>
 	<release-note plugin-version="31">
-Fixes APAR PI81623 Deployments failing in IIB 9 and lower.	
+Fixes APAR PI81623 Deployments failing in IIB 9 and lower.
 	</release-note>
     <release-note plugin-version="32">
 Provide proper error output when execution group doesn't exist.
+Fixes APAR PI80814 The Deploy and Delete Flow using RegEx steps use the timeout instead of DEPLOYRESULT_WAIT_INDEFINITELY.
     </release-note>
-	
+
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -117,7 +117,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -245,7 +245,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -372,7 +372,8 @@
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB, and
                                   the maximum amount of time to wait for the server to stop/start. Leave empty or use -1
-                                  to wait indefinitely. Increase if experiencing 'ConfigManagerProxyRequestTimoutException',
+                                  to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang.
+                                  Increase if experiencing 'ConfigManagerProxyRequestTimoutException',
                                   or if the execution group was unable to stop by the given time interval."
                      hidden="true"/>
       </property>
@@ -504,7 +505,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -653,7 +654,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -784,7 +785,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -927,7 +928,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -1057,7 +1058,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -1208,7 +1209,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -1338,7 +1339,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -1468,7 +1469,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">
@@ -1558,7 +1559,7 @@
                      label="Timeout"
                      default-value="120000"
                      description="The maximum time in milliseconds to wait for a response from WebSphere IIB. Increase if experiencing Timeout Exceptions.
-                                  Leave empty or set to -1 to wait indefinitely."
+                                  Leave empty or set to -1 to wait indefinitely. Note: Setting the timeout as -1 may cause the step to hang."
                      hidden="true"/>
       </property>
       <property name="shell">


### PR DESCRIPTION
- DEPLOYRESULT_WAIT_INDEFINITELY can cause the step to hang without
explanation.
- Updated timeout description to alert user that -1 may cause hanging.