### PR TITLE
164870

### DIFF
--- a/src/main/groovy/com/urbancode/air/plugin/wmbcmp/IIBHelper.groovy
+++ b/src/main/groovy/com/urbancode/air/plugin/wmbcmp/IIBHelper.groovy
@@ -521,12 +521,7 @@ class IIBHelper {
             BrokerProxy.disableAdministrationAPITracing()
         }
 
-        if (brokerProxy && (versionInt < 10)) {
-            brokerProxy.disconnect()
-        }
-        else if (brokerProxy) {
-           brokerProxy.disconnectAll()
-        }
+        brokerProxy.disconnect()
     }
 
     private ExecutionGroupProxy getExecutionGroup(String groupName) {


### PR DESCRIPTION
The BrokerProxy.disconnectAll() function only exists in certain
versions of the IIB 10 Integration API jar files.